### PR TITLE
Weakened containers bound

### DIFF
--- a/json-api-lib.cabal
+++ b/json-api-lib.cabal
@@ -28,7 +28,7 @@ source-repository head
 library
   build-depends: aeson         > 1.4 && < 1.6
                , base          >= 4.11 && < 5
-               , containers    >= 0.6.1 && < 0.7
+               , containers    >= 0.5.11 && < 0.7
                , data-default  >= 0.7.1 && < 0.8
                , deepseq       >= 1.4 && < 1.5
                , lens          >= 4.17.1 && < 4.20
@@ -71,7 +71,7 @@ test-suite json-api-lib-test
                , aeson-pretty  > 0.8 && < 0.9
                , base          >= 4.11 && < 5
                , bytestring    >= 0.10.8 && < 0.11
-               , containers    >= 0.6.1 && < 0.7
+               , containers    >= 0.5.11 && < 0.7
                , data-default  >= 0.7.1 && < 0.8
                , hspec         >= 2.7.1 && < 2.8
                , json-api-lib


### PR DESCRIPTION
When compiling a certain package set I noticed that this bound was too restrictive.

We'll either want to do a 0.3.0.1 or a metadata revision. What do you reckon @gwils ?